### PR TITLE
:arrow_up: chore: upgrade dependencies

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,21 +3,21 @@
   "isRoot": true,
   "tools": {
     "gitversion.tool": {
-      "version": "6.4.0",
+      "version": "6.5.0",
       "commands": [
         "dotnet-gitversion"
       ],
       "rollForward": false
     },
     "dotnet-coverage": {
-      "version": "17.14.2",
+      "version": "18.1.0",
       "commands": [
         "dotnet-coverage"
       ],
       "rollForward": false
     },
     "dotnet-reportgenerator-globaltool": {
-      "version": "5.4.12",
+      "version": "5.5.0",
       "commands": [
         "reportgenerator"
       ],

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -46,11 +46,11 @@ jobs:
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
       - name: Setup latest dotnet sdk
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 9.0
       - name: Install ASP.NET Core runtimes (6.0, 8.0)
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             6.0.x
@@ -65,7 +65,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
       - name: 'Publish: ProtectedNumbers build artefacts'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ProtectedNumbers-build-artefacts
           path: .build/publish/nuget

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,17 +5,17 @@
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="CSharpGuidelinesAnalyzer" Version="3.8.5" />
-    <PackageVersion Include="FastEndpoints" Version="7.0.1" />
-    <PackageVersion Include="Meziantou.Analyzer" Version="2.0.213" />
+    <PackageVersion Include="FastEndpoints" Version="7.1.1" />
+    <PackageVersion Include="Meziantou.Analyzer" Version="2.0.253" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageVersion Include="Nuke.Common" Version="9.0.4" />
     <PackageVersion Include="NUnit" Version="4.4.0" />
-    <PackageVersion Include="NUnit.Analyzers" Version="4.10.0" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="5.1.0" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.11.2" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="5.2.0" />
     <PackageVersion Include="PolySharp" Version="1.15.0" />
-    <PackageVersion Include="Roslynator.Analyzers" Version="4.14.0" />
+    <PackageVersion Include="Roslynator.Analyzers" Version="4.14.1" />
     <PackageVersion Include="SharpGrip.FluentValidation.AutoValidation.Endpoints" Version="1.5.0" />
     <PackageVersion Include="SharpGrip.FluentValidation.AutoValidation.Mvc" Version="1.5.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
@@ -25,9 +25,9 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
   </ItemGroup>
 </Project>

--- a/tst/ProtectedNumbers.Tests/ProtectedNumbers.Tests.csproj
+++ b/tst/ProtectedNumbers.Tests/ProtectedNumbers.Tests.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <SuppressTfmSupportBuildErrors>true</SuppressTfmSupportBuildErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- upgrade actions/setup-dotnet action to v5
- upgrade actions/upload-artifact action to v5
- upgrade dependency gitversion.tool to v6.5.0
- upgrade dependency dotnet-coverage to v18.1.0
- upgrade dependency dotnet-reportgenerator-globaltool to v5.5.0
- upgrade dependency FastEndpoints to v7.1.1
- upgrade dependency Meziantou.Analyzer to v2.0.253
- upgrade dependency NUnit.Analyzers to v4.11.2
- upgrade dependency NUnit3TestAdapter to v5.2.0
- upgrade dependency Roslynator.Analyzers to v4.14.1
- upgrade dependency Microsoft.NET.Test.Sdk to v18.0.1